### PR TITLE
Output separate YAML files for cisagov conversion

### DIFF
--- a/src/mdyml/convert_cisagov.py
+++ b/src/mdyml/convert_cisagov.py
@@ -22,6 +22,7 @@ Options:
 # Standard Python Libraries
 from datetime import datetime, timezone
 import html
+from itertools import groupby
 import logging
 import sys
 from typing import Any
@@ -36,6 +37,7 @@ from schema import And, Schema, SchemaError, Use
 from . import DEFAULT_CVE_ID, MD_LINK_RE, ORDERED_CVE_IDS, __version__
 
 RAW_URL = "https://raw.githubusercontent.com/cisagov/log4j-affected-db/develop/SOFTWARE-LIST.md"
+SOFTWARE_LIST_FILE_FORMAT = "cisagov_{}.yml"
 
 EXPECTED_COLUMN_NAMES = [
     "vendor",
@@ -160,15 +162,31 @@ def convert() -> None:
 
         out_dict_list.append(out_dict)
 
-    doc = {"version": "1.0", "software": out_dict_list}
+    out_dict_groups = {
+        k: list(g)
+        for k, g in groupby(out_dict_list, key=lambda s: s["vendor"][0].upper())
+    }
 
-    yaml = ruamel.yaml.YAML()
-    yaml.indent(mapping=2, offset=2, sequence=4)
-    yaml.explicit_start = True
-    yaml.explicit_end = True
-    yaml.sort_base_mapping_type_on_output = False
-    yaml.allow_unicode = True
-    yaml.dump(doc, sys.stdout)
+    non_letter_groups = list()
+    for key in list(out_dict_groups.keys()):
+        if not key.isalpha():
+            non_letter_groups.extend(out_dict_groups[key])
+            del out_dict_groups[key]
+    out_dict_groups["0-9"] = non_letter_groups
+
+    for key, data in out_dict_groups.items():
+        filename = SOFTWARE_LIST_FILE_FORMAT.format(key)
+        logging.debug("Writing data for '%s' to '%s'", key, filename)
+        with open(filename, "w") as out_file:
+            doc = {"version": "1.0", "software": data}
+
+            yaml = ruamel.yaml.YAML()
+            yaml.indent(mapping=2, offset=2, sequence=4)
+            yaml.explicit_start = True
+            yaml.explicit_end = True
+            yaml.sort_base_mapping_type_on_output = False
+            yaml.allow_unicode = True
+            yaml.dump(doc, out_file)
 
 
 def main() -> None:

--- a/src/mdyml/convert_cisagov.py
+++ b/src/mdyml/convert_cisagov.py
@@ -172,7 +172,7 @@ def convert() -> None:
         if not key.isalpha():
             non_letter_groups.extend(out_dict_groups[key])
             del out_dict_groups[key]
-    out_dict_groups["0-9"] = non_letter_groups
+    out_dict_groups["Non-Alphabet"] = non_letter_groups
 
     for key, data in out_dict_groups.items():
         filename = SOFTWARE_LIST_FILE_FORMAT.format(key)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request changes the `convert-cisagov` script from printing the YAML for the convert Markdown to `stdout` to instead output a series of files in a pre-defined format. These files contain entries grouped by the first character (in uppercase) of the product vendor.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The resultant YAML file from converting the existing Markdown file is too large for the GitHub web UI to work with. There is an API limitation of 1MiB that a file needs to stay under for the web UI to allow in-browser editing/viewing. When the converted YAML is distributed across multiple files we can keep the individual file size to well below the 1MiB limit.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I confirmed that the processed Markdown is split up in the specified way when run locally.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
