### PR TITLE
Replace individual `reporter` keys with a document top-level `owners` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,14 @@ software:
           - 1.2
         investigated: true
         unaffected_versions: []
+    last_updated: "2021-12-09"
     notes: Blah blah blah
     product: ProductA
     references:
       - https://www.reddit.com/r/Vendor1/comments/abcdef/log4j
-    reporter: cisagov
     vendor: Vendor1
     vendor_links:
       - https://vendor1.com/discussion/comment/622612/#Comment_622612
-    last_updated: "2021-12-09"
   ⋮
 ...
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The common YAML format looks like this:
 ```yaml
 ---
 version: '1.0'
+owners:
+  - name: cisagov
+    url: https://github.com/cisagov/log4j-affected-db
 software:
   -  cves:
       - affected_versions:

--- a/src/mdyml/convert_cisagov.py
+++ b/src/mdyml/convert_cisagov.py
@@ -147,7 +147,6 @@ def convert() -> None:
 
         out_dict["notes"] = in_row_dict["notes"]
         out_dict["references"] = [in_row_dict["references"]]
-        out_dict["reporter"] = "cisagov"
         # Parse the existing date, or not
         if parsed_date := dateparser.parse(in_row_dict["last_updated"]):
             # Check if parsed date has a timezone
@@ -178,7 +177,16 @@ def convert() -> None:
         filename = SOFTWARE_LIST_FILE_FORMAT.format(key)
         logging.debug("Writing data for '%s' to '%s'", key, filename)
         with open(filename, "w") as out_file:
-            doc = {"version": "1.0", "software": data}
+            doc = {
+                "version": "1.0",
+                "owners": [
+                    {
+                        "name": "cisagov",
+                        "url": "https://github.com/cisagov/log4j-affected-db",
+                    }
+                ],
+                "software": data,
+            }
 
             yaml = ruamel.yaml.YAML()
             yaml.indent(mapping=2, offset=2, sequence=4)

--- a/src/yml/normalize_yml.py
+++ b/src/yml/normalize_yml.py
@@ -39,7 +39,7 @@ Software = list[dict[str, Any]]
 def munge(
     filenames: list[str], owners: list[dict[str, str]] = [], canonical=False
 ) -> Software:
-    """Munge together the "software" nodes from YAML files into a single Python dictionary."""
+    """Munge together the "owners" and "software" nodes from YAML files into a single Python dictionary."""
     ans = []
     for filename in filenames:
         with open(filename, "r") as f:

--- a/src/ymlmd/yml2md.py
+++ b/src/ymlmd/yml2md.py
@@ -111,7 +111,9 @@ def generate_markdown(software: Software) -> None:
                     ),
                     notes=s["notes"],
                     references="; ".join([x for x in s["references"] if len(x) != 0]),
-                    reporter=s["reporter"],
+                    reporter=", ".join(
+                        f"[{i['name']}]({i['url']})" for i in s["reporter"]
+                    ),
                     # create a datetime from string and print date portion
                     last_updated=dateparser.parse(s["last_updated"]).strftime(
                         "%Y-%m-%d"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request replaces tracking the `reporter` for each product entry with tracking it on a per-file basis using an `owners` key that is a list of data owners. Changes are made to support using this new key to populate the `Reporter` field when outputting to Markdown as well as collating an de-duplicating entries when merging YAML files.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This makes it clear that it is not intended for submitters to modify who is reporting data. That field is meant to inform end consumers who own the data so change requests can be taken back to the source.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I tested this functionality in [cisagov/github-actions-playerground/testing/log4j_list_update](https://github.com/cisagov/github-actions-playground/tree/testing/log4j_list_update) where you can see the resultant files. I tested the de-duplication and owner collating logic locally to handle cases not seen with the setup in the aforementioned branch.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
