### PR TITLE
Fix bug in the `convert-cisagov` command

### DIFF
--- a/src/mdyml/convert_cisagov.py
+++ b/src/mdyml/convert_cisagov.py
@@ -161,9 +161,14 @@ def convert() -> None:
 
         out_dict_list.append(out_dict)
 
+    # Sort in the same manner groupby() will group entries
+    out_dict_list.sort(key=lambda p: p["vendor"][0].lower())
+
+    logging.debug("Total rows for grouping: %d", len(out_dict_list))
+
     out_dict_groups = {
-        k: list(g)
-        for k, g in groupby(out_dict_list, key=lambda s: s["vendor"][0].upper())
+        k.upper(): list(g)
+        for k, g in groupby(out_dict_list, key=lambda s: s["vendor"][0].lower())
     }
 
     non_letter_groups = list()
@@ -173,10 +178,13 @@ def convert() -> None:
             del out_dict_groups[key]
     out_dict_groups["Non-Alphabet"] = non_letter_groups
 
+    total_group_count = 0
     for key, data in out_dict_groups.items():
         filename = SOFTWARE_LIST_FILE_FORMAT.format(key)
         logging.debug("Writing data for '%s' to '%s'", key, filename)
         with open(filename, "w") as out_file:
+            group_count = len(data)
+            total_group_count += group_count
             doc = {
                 "version": "1.0",
                 "owners": [
@@ -195,6 +203,10 @@ def convert() -> None:
             yaml.sort_base_mapping_type_on_output = False
             yaml.allow_unicode = True
             yaml.dump(doc, out_file)
+
+            logging.debug("Group '%s' rows: %d", key, group_count)
+
+    logging.debug("Total grouped rows processed: %d", total_group_count)
 
 
 def main() -> None:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request fixes a bug in the `convert-cisagov` command's functionality that resulted in rows being dropped while grouping. Additionally debug output was added to provide good indicators on things processing correctly if needed.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This bug resulted in row from the Markdown file being read in getting dropped when using `itertool.groupby()`. The root cause is that the source list needs to be sorted using the same logic that is used to group elements.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I confirmed with the new debug output that the same number of rows that were read in were in the grouped data and that output files looked appropriate.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
