### PR TITLE
Consistently sort output YAML

### DIFF
--- a/src/mdyml/convert_cisagov.py
+++ b/src/mdyml/convert_cisagov.py
@@ -193,7 +193,9 @@ def convert() -> None:
                         "url": "https://github.com/cisagov/log4j-affected-db",
                     }
                 ],
-                "software": data,
+                "software": sorted(
+                    data, key=lambda p: (p["vendor"].lower(), p["product"].lower())
+                ),
             }
 
             yaml = ruamel.yaml.YAML()

--- a/src/yml/normalize_yml.py
+++ b/src/yml/normalize_yml.py
@@ -65,7 +65,7 @@ def normalize(data: YamlData) -> YamlData:
 
 def sort(data: YamlData) -> YamlData:
     """Sort the software entries."""
-    data["software"].sort(key=lambda x: (x["vendor"] + x["product"]).lower())
+    data["software"].sort(key=lambda x: (x["vendor"].lower(), x["product"].lower()))
     return data
 
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pr updates the `convert-cisagov` command to sort the `software` entries in the converted Markdown's YAML output by vendor and then product. It also updates the sorting functionality in the `normalize-yml` to sort in the same manner.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This most human-friendly sorting is that which sorts on two values plainly instead of combining them. Since Python allows that with its sorting it is better to switch to that method for output. Just for a consistent experience the initial converted output from `convert-cisagov` is updated to be sorted the same way.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
