### PR TITLE
Use the same default timestamp for converted data in `convert-cisagov`

### DIFF
--- a/src/mdyml/convert_cisagov.py
+++ b/src/mdyml/convert_cisagov.py
@@ -87,6 +87,11 @@ def convert() -> None:
             table_rows.append(line)
     logging.info("Done reading Markdown table with %d rows.", len(table_rows))
 
+    # The timestamp to use if there is no timestamp in the row. Since the
+    # conversion is logically one action it should be the same for all converted
+    # data.
+    default_timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
     # Process all the data into a list of dictionaries
     out_dict_list = []
     row_count = 0
@@ -155,9 +160,7 @@ def convert() -> None:
                 parsed_date.replace(tzinfo=timezone.utc)
             out_dict["last_updated"] = parsed_date.isoformat(timespec="seconds")
         else:
-            out_dict["last_updated"] = datetime.now(timezone.utc).isoformat(
-                timespec="seconds"
-            )
+            out_dict["last_updated"] = default_timestamp
 
         out_dict_list.append(out_dict)
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the `convert-cisagov` command to use the same default timestamp for any rows missing a timestamp when converting.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The conversion process is logically one moment in time and so all entries that need a timestamp should use the same timestamp. Though this is not particularly relevant since we are post-conversion, this mirrors how NCSC-NL data will be timestamped when that is updated and deployed.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I did a test import with an old version of the Markdown source file and it worked as expected.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
