### PR TITLE
Ensure values are `str` types when converting from YAML to Markdown

### DIFF
--- a/src/ymlmd/yml2md.py
+++ b/src/ymlmd/yml2md.py
@@ -120,8 +120,8 @@ def generate_markdown(software: Software) -> None:
                     ),
                 )
             )
-        except KeyError as err:
-            print(f"{i}: {err} - {s}", file=sys.stderr)
+        except KeyError:
+            logging.exception("%d: %s", i, s)
 
 
 def main() -> None:

--- a/src/ymlmd/yml2md.py
+++ b/src/ymlmd/yml2md.py
@@ -95,10 +95,18 @@ def generate_markdown(software: Software) -> None:
                     vendor=s["vendor"],
                     product=s["product"],
                     affected_versions=", ".join(
-                        [x for x in default_cve["affected_versions"] if len(x) != 0]
+                        [
+                            v
+                            for x in default_cve["affected_versions"]
+                            if x and len(v := str(x)) != 0
+                        ]
                     ),
                     patched_versions=", ".join(
-                        [x for x in default_cve["fixed_versions"] if len(x) != 0]
+                        [
+                            v
+                            for x in default_cve["fixed_versions"]
+                            if x and len(v := str(x)) != 0
+                        ]
                     ),
                     status=s["status"],
                     # convert vendor links to Markdown links if they start
@@ -110,7 +118,9 @@ def generate_markdown(software: Software) -> None:
                         ]
                     ),
                     notes=s["notes"],
-                    references="; ".join([x for x in s["references"] if len(x) != 0]),
+                    references="; ".join(
+                        [r for x in s["references"] if x and len(r := str(x)) != 0]
+                    ),
                     reporter=", ".join(
                         f"[{i['name']}]({i['url']})" for i in s["reporter"]
                     ),


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates portions of the `yml2md` command so that any values where we check the `len()` is checked for truthiness and converted with `str()` first. It also converts a piece of error handling from manually printing to `stderr` to instead use the `logging` library appropriately.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

When a person who is unfamiliar with YAML is updating an entry they may see no problem with the following:

```yaml
  affected_versions:
    - < 1.4
    - 1.5
    - '> 1.6'
```

However, the second value will be read as a `float` value instead of as a `str` value. This will cause the `yml2md` command to fail with a `TypeError` when processing this entry.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. When run with the sample version data above the `v1.1.1` branch fails with a `TypeError` as expected. When used with this branch the conversion completes with no issues.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
