### PR TITLE
Disable aliases in YAML output

### DIFF
--- a/src/mdyml/convert_cisagov.py
+++ b/src/mdyml/convert_cisagov.py
@@ -53,6 +53,14 @@ EXPECTED_COLUMN_NAMES = [
 EXPECTED_COLUMN_COUNT = len(EXPECTED_COLUMN_NAMES)
 
 
+class NoAliasesRoundTripRepresenter(ruamel.yaml.representer.RoundTripRepresenter):
+    """Helper class to eliminate YAML anchors in YAML output."""
+
+    def ignore_aliases(self, data):
+        """Override the default method to always ignore aliases."""
+        return True
+
+
 def convert() -> None:
     """Parse the Markdown at the given URL and convert it to YAML."""
     # Get the Markdown
@@ -202,6 +210,7 @@ def convert() -> None:
             }
 
             yaml = ruamel.yaml.YAML()
+            yaml.Representer = NoAliasesRoundTripRepresenter
             yaml.indent(mapping=2, offset=2, sequence=4)
             yaml.explicit_start = True
             yaml.explicit_end = True

--- a/src/yml/normalize_yml.py
+++ b/src/yml/normalize_yml.py
@@ -38,6 +38,14 @@ Owners = list[dict[str, str]]
 YamlData = dict[str, Software | Owners]
 
 
+class NoAliasesRoundTripRepresenter(ruamel.yaml.representer.RoundTripRepresenter):
+    """Helper class to eliminate YAML anchors in YAML output."""
+
+    def ignore_aliases(self, data):
+        """Override the default method to always ignore aliases."""
+        return True
+
+
 def munge(filenames: list[str], canonical=False) -> YamlData:
     """Munge together the "owners" and "software" nodes from YAML files into a single Python dictionary."""
     ans = []
@@ -116,6 +124,7 @@ def main() -> None:
         doc = data["software"]
 
     yml = ruamel.yaml.YAML()
+    yml.Representer = NoAliasesRoundTripRepresenter
     yml.indent(mapping=2, offset=2, sequence=4)
     yml.explicit_start = True
     yml.explicit_end = True


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a helper class to ensure that YAML output always ignores aliases. This is done specifically to remove anchors from YAML output.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Given the nature of how these YAML files are updated and processed we should ensure that running `normalize-yml` on any given YAML file will not remove data from an entry. This will ensure that every entry preserves all data is it meant to contain.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that a YAML file processed with `normalize-yml` does not have anchors, and that missing anchors is the only change observed.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
